### PR TITLE
学習用コメントを必要な箇所に追加する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
+        {/* 認証ガード未実装の間は、アプリ起動時にダッシュボードへ直接遷移させる。 */}
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="/login" element={<LoginPage />} />
         <Route element={<AppLayout />}>

--- a/src/features/tasks/mockTasks.ts
+++ b/src/features/tasks/mockTasks.ts
@@ -1,5 +1,6 @@
 import type { Task } from './types'
 
+// DB連携前でも一覧画面を実装できるよう、タスク機能の仮データを分離しておく。
 export const mockTasks: Task[] = [
   {
     id: 'task-1',

--- a/src/features/tasks/types.ts
+++ b/src/features/tasks/types.ts
@@ -9,6 +9,7 @@ export type TaskCategory =
   | 'interview'
   | 'document'
 
+// MVPでは詳細ページを持たないため、一覧表示と追加操作に必要な項目だけを含める。
 export type Task = {
   id: string
   title: string

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 function LoginPage() {
   const navigate = useNavigate()
 
+  // 認証処理は未実装のため、現時点ではログイン後画面への遷移だけを確認する。
   const goToDashboard = () => {
     navigate('/dashboard')
   }


### PR DESCRIPTION
## 概要

学習用ポートフォリオとしてコードを読み返しやすくするため、必要な箇所にだけコメントを追加しました。

## 変更内容

- 認証ガード未実装中のルート / から /dashboard へのリダイレクト意図を追記
- ログイン画面の仮遷移の理由を追記
- MVPでTask型を一覧表示と追加操作に必要な項目へ絞っている理由を追記
- DB連携前にタスクの仮データを src/features 配下へ分離している理由を追記

## コメント追加方針

- 何をしているかではなく、なぜそうしているかを補足
- 型名や変数名から分かる説明は追加しない
- MVP上の制約や将来拡張の意図がある箇所に限定
- コメントを増やしすぎないよう、4箇所のみ追加

## 動作確認

- [x] npm run lint
- [x] npm run build

Closes #9