### PR TITLE
Issue #12 TaskCardコンポーネントを作成する

### DIFF
--- a/src/features/tasks/components/TaskCard.tsx
+++ b/src/features/tasks/components/TaskCard.tsx
@@ -1,0 +1,36 @@
+import {
+  taskCategoryLabels,
+  taskPriorityLabels,
+  taskStatusLabels,
+} from '../taskLabels'
+import type { Task } from '../types'
+
+type TaskCardProps = {
+  task: Task
+}
+
+export function TaskCard({ task }: TaskCardProps) {
+  return (
+    <article className="task-card">
+      <div className="task-card-main">
+        <p className="task-category">{taskCategoryLabels[task.category]}</p>
+        <h2>{task.title}</h2>
+      </div>
+
+      <dl className="task-meta">
+        <div>
+          <dt>ステータス</dt>
+          <dd>{taskStatusLabels[task.status]}</dd>
+        </div>
+        <div>
+          <dt>優先度</dt>
+          <dd>{taskPriorityLabels[task.priority]}</dd>
+        </div>
+        <div>
+          <dt>期限</dt>
+          <dd>{task.dueDate ?? '未設定'}</dd>
+        </div>
+      </dl>
+    </article>
+  )
+}

--- a/src/features/tasks/taskLabels.ts
+++ b/src/features/tasks/taskLabels.ts
@@ -1,0 +1,22 @@
+import type { TaskCategory, TaskPriority, TaskStatus } from './types'
+
+// Taskの内部値と画面表示用の日本語ラベルを分け、今後のフォームや絞り込みでも同じ文言を使えるようにする。
+export const taskStatusLabels: Record<TaskStatus, string> = {
+  todo: '未着手',
+  inProgress: '進行中',
+  done: '完了',
+}
+
+export const taskPriorityLabels: Record<TaskPriority, string> = {
+  high: '高',
+  medium: '中',
+  low: '低',
+}
+
+export const taskCategoryLabels: Record<TaskCategory, string> = {
+  learning: '学習',
+  portfolio: 'ポートフォリオ',
+  application: '応募',
+  interview: '面接対策',
+  document: 'ドキュメント',
+}

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -1,29 +1,5 @@
+import { TaskCard } from '../features/tasks/components/TaskCard'
 import { mockTasks } from '../features/tasks/mockTasks'
-import type {
-  TaskCategory,
-  TaskPriority,
-  TaskStatus,
-} from '../features/tasks/types'
-
-const taskStatusLabels: Record<TaskStatus, string> = {
-  todo: '未着手',
-  inProgress: '進行中',
-  done: '完了',
-}
-
-const taskPriorityLabels: Record<TaskPriority, string> = {
-  high: '高',
-  medium: '中',
-  low: '低',
-}
-
-const taskCategoryLabels: Record<TaskCategory, string> = {
-  learning: '学習',
-  portfolio: 'ポートフォリオ',
-  application: '応募',
-  interview: '面接対策',
-  document: 'ドキュメント',
-}
 
 function TasksPage() {
   return (
@@ -39,29 +15,7 @@ function TasksPage() {
       {mockTasks.length > 0 ? (
         <div className="task-list" aria-label="タスク一覧">
           {mockTasks.map((task) => (
-            <article className="task-card" key={task.id}>
-              <div className="task-card-main">
-                <p className="task-category">
-                  {taskCategoryLabels[task.category]}
-                </p>
-                <h2>{task.title}</h2>
-              </div>
-
-              <dl className="task-meta">
-                <div>
-                  <dt>ステータス</dt>
-                  <dd>{taskStatusLabels[task.status]}</dd>
-                </div>
-                <div>
-                  <dt>優先度</dt>
-                  <dd>{taskPriorityLabels[task.priority]}</dd>
-                </div>
-                <div>
-                  <dt>期限</dt>
-                  <dd>{task.dueDate ?? '未設定'}</dd>
-                </div>
-              </dl>
-            </article>
+            <TaskCard key={task.id} task={task} />
           ))}
         </div>
       ) : (


### PR DESCRIPTION
## 概要
TasksPage.tsx に直接書いていたタスク1件分の表示を TaskCard コンポーネントへ分離しました。

## 変更内容
- src/features/tasks/components/TaskCard.tsx を追加
- src/features/tasks/taskLabels.ts を追加
- TasksPage.tsx から TaskCard を利用するように変更
- ステータス・優先度・カテゴリの日本語ラベル定義を taskLabels.ts に移動

## 動作確認
- [x] npm run lint
- [x] npm run build

Closes #12