### PR TITLE
タスク追加フォームを作成する

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -95,6 +95,71 @@
   color: var(--text-muted);
 }
 
+.task-form-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  margin-top: 28px;
+  padding: 22px;
+}
+
+.task-form-heading {
+  margin-bottom: 18px;
+}
+
+.task-form-heading h2 {
+  color: var(--text-strong);
+  font-size: 20px;
+  margin: 0 0 6px;
+}
+
+.task-form-heading p {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.task-form {
+  display: grid;
+  gap: 18px;
+}
+
+.task-form-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(220px, 2fr) repeat(3, minmax(140px, 1fr));
+}
+
+.form-field {
+  color: var(--text-strong);
+  display: grid;
+  font-size: 14px;
+  font-weight: 700;
+  gap: 8px;
+}
+
+.form-field input,
+.form-field select {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-strong);
+  font: inherit;
+  min-height: 42px;
+  padding: 10px 12px;
+}
+
+.form-field input:focus,
+.form-field select:focus {
+  border-color: var(--accent);
+  outline: 3px solid rgba(22, 97, 102, 0.16);
+}
+
+.task-form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .dashboard-grid {
   display: grid;
   gap: 16px;
@@ -332,8 +397,17 @@
   }
 
   .dashboard-grid,
+  .task-form-grid,
   .login-panel {
     grid-template-columns: 1fr;
+  }
+
+  .task-form-actions {
+    justify-content: stretch;
+  }
+
+  .task-form-actions .primary-button {
+    width: 100%;
   }
 
   .task-card,

--- a/src/features/tasks/components/TaskForm.tsx
+++ b/src/features/tasks/components/TaskForm.tsx
@@ -1,0 +1,105 @@
+import type { FormEvent } from 'react'
+import { useState } from 'react'
+
+import { taskCategoryLabels, taskPriorityLabels } from '../taskLabels'
+import type { TaskCategory, TaskPriority } from '../types'
+
+const taskPriorityOptions: TaskPriority[] = ['high', 'medium', 'low']
+
+const taskCategoryOptions: TaskCategory[] = [
+  'learning',
+  'portfolio',
+  'application',
+  'interview',
+  'document',
+]
+
+export function TaskForm() {
+  const [title, setTitle] = useState('')
+  const [priority, setPriority] = useState<TaskPriority>('medium')
+  const [dueDate, setDueDate] = useState('')
+  const [category, setCategory] = useState<TaskCategory>('learning')
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    // 追加処理は次のIssueで実装するため、今回はフォーム入力だけを確認できる状態にする。
+  }
+
+  return (
+    <section className="task-form-panel" aria-labelledby="task-form-title">
+      <div className="task-form-heading">
+        <h2 id="task-form-title">タスクを追加</h2>
+        <p>次に取り組む行動を、まずは入力できる形にします。</p>
+      </div>
+
+      <form className="task-form" onSubmit={handleSubmit}>
+        <div className="task-form-grid">
+          <label className="form-field" htmlFor="task-title">
+            タイトル
+            <input
+              id="task-title"
+              name="title"
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="例: React Routerを復習する"
+              type="text"
+              value={title}
+            />
+          </label>
+
+          <label className="form-field" htmlFor="task-priority">
+            優先度
+            <select
+              id="task-priority"
+              name="priority"
+              onChange={(event) =>
+                setPriority(event.target.value as TaskPriority)
+              }
+              value={priority}
+            >
+              {taskPriorityOptions.map((option) => (
+                <option key={option} value={option}>
+                  {taskPriorityLabels[option]}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="form-field" htmlFor="task-due-date">
+            期限
+            <input
+              id="task-due-date"
+              name="dueDate"
+              onChange={(event) => setDueDate(event.target.value)}
+              type="date"
+              value={dueDate}
+            />
+          </label>
+
+          <label className="form-field" htmlFor="task-category">
+            カテゴリ
+            <select
+              id="task-category"
+              name="category"
+              onChange={(event) =>
+                setCategory(event.target.value as TaskCategory)
+              }
+              value={category}
+            >
+              {taskCategoryOptions.map((option) => (
+                <option key={option} value={option}>
+                  {taskCategoryLabels[option]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="task-form-actions">
+          <button className="primary-button" type="submit">
+            追加
+          </button>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -33,7 +33,8 @@ body {
 }
 
 button,
-input {
+input,
+select {
   font: inherit;
 }
 

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -1,3 +1,4 @@
+import { TaskForm } from '../features/tasks/components/TaskForm'
 import { TaskCard } from '../features/tasks/components/TaskCard'
 import { mockTasks } from '../features/tasks/mockTasks'
 
@@ -11,6 +12,8 @@ function TasksPage() {
           学習タスクや転職活動タスクを登録し、進捗を管理する画面になる予定です。
         </p>
       </div>
+
+      <TaskForm />
 
       {mockTasks.length > 0 ? (
         <div className="task-list" aria-label="タスク一覧">


### PR DESCRIPTION
## 概要

/tasks にタスク追加フォームを表示し、タスクのタイトル・優先度・期限・カテゴリを入力できるようにしました。

## 変更内容

- TaskForm コンポーネントを追加
- 優先度とカテゴリの選択肢に taskLabels.ts のラベル定義を利用
- TasksPage にフォームを表示
- 既存UIに合わせてフォーム用スタイルを追加

## 動作確認

- [x] npm run lint
- [x] npm run build
- [x] /tasks がローカル開発サーバーで表示されることを確認

Closes #13