### PR TITLE
タスク追加処理を実装する

### DIFF
--- a/src/features/tasks/components/TaskForm.tsx
+++ b/src/features/tasks/components/TaskForm.tsx
@@ -2,7 +2,7 @@ import type { FormEvent } from 'react'
 import { useState } from 'react'
 
 import { taskCategoryLabels, taskPriorityLabels } from '../taskLabels'
-import type { TaskCategory, TaskPriority } from '../types'
+import type { TaskCategory, TaskFormValues, TaskPriority } from '../types'
 
 const taskPriorityOptions: TaskPriority[] = ['high', 'medium', 'low']
 
@@ -14,7 +14,11 @@ const taskCategoryOptions: TaskCategory[] = [
   'document',
 ]
 
-export function TaskForm() {
+type TaskFormProps = {
+  onAddTask: (values: TaskFormValues) => void
+}
+
+export function TaskForm({ onAddTask }: TaskFormProps) {
   const [title, setTitle] = useState('')
   const [priority, setPriority] = useState<TaskPriority>('medium')
   const [dueDate, setDueDate] = useState('')
@@ -22,7 +26,25 @@ export function TaskForm() {
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    // 追加処理は次のIssueで実装するため、今回はフォーム入力だけを確認できる状態にする。
+
+    const trimmedTitle = title.trim()
+
+    if (trimmedTitle === '') {
+      setTitle('')
+      return
+    }
+
+    onAddTask({
+      title: trimmedTitle,
+      priority,
+      dueDate: dueDate || null,
+      category,
+    })
+
+    setTitle('')
+    setPriority('medium')
+    setDueDate('')
+    setCategory('learning')
   }
 
   return (

--- a/src/features/tasks/types.ts
+++ b/src/features/tasks/types.ts
@@ -20,3 +20,11 @@ export type Task = {
   createdAt: string
   updatedAt: string
 }
+
+// フォームでは、idや作成日時などの自動生成する項目を扱わず、ユーザーが入力する項目だけを渡す。
+export type TaskFormValues = {
+  title: string
+  priority: TaskPriority
+  dueDate: string | null
+  category: TaskCategory
+}

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -1,8 +1,28 @@
+import { useState } from 'react'
 import { TaskForm } from '../features/tasks/components/TaskForm'
 import { TaskCard } from '../features/tasks/components/TaskCard'
 import { mockTasks } from '../features/tasks/mockTasks'
+import type { Task, TaskFormValues } from '../features/tasks/types'
 
 function TasksPage() {
+  const [tasks, setTasks] = useState<Task[]>(mockTasks)
+
+  function handleAddTask(values: TaskFormValues) {
+    const now = new Date().toISOString()
+    const newTask: Task = {
+      id: crypto.randomUUID(),
+      title: values.title,
+      status: 'todo',
+      priority: values.priority,
+      dueDate: values.dueDate,
+      category: values.category,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    setTasks((currentTasks) => [...currentTasks, newTask])
+  }
+
   return (
     <section className="page-section">
       <div className="page-heading">
@@ -13,11 +33,11 @@ function TasksPage() {
         </p>
       </div>
 
-      <TaskForm />
+      <TaskForm onAddTask={handleAddTask} />
 
-      {mockTasks.length > 0 ? (
+      {tasks.length > 0 ? (
         <div className="task-list" aria-label="タスク一覧">
-          {mockTasks.map((task) => (
+          {tasks.map((task) => (
             <TaskCard key={task.id} task={task} />
           ))}
         </div>


### PR DESCRIPTION
## 概要

タスク追加フォームに入力した内容を、Reactのstateでタスク一覧へ追加できるようにしました。DB保存やlocalStorage保存はまだ行っていません。

## 変更内容

- TasksPageでtasks stateを管理
- mockTasksをstateの初期値として利用
- TaskFormから入力内容を親へ渡すpropsを追加
- 新規Taskのid、status、createdAt、updatedAtを追加時に設定
- 空タイトルの追加を防止
- 期限未入力時はdueDateをnullに変換
- 追加後にフォームをリセット

## 動作確認

- [x] npm run lint
- [x] npm run build
- [x] /tasks がローカル開発サーバーで表示されることを確認

Closes #17