### PR TITLE
タスク削除処理を実装する

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -196,7 +196,7 @@
   box-shadow: var(--shadow);
   display: grid;
   gap: 18px;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto auto;
   padding: 20px 22px;
 }
 
@@ -241,6 +241,15 @@
   font-size: 14px;
   font-weight: 700;
   margin: 0;
+}
+
+.task-card-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.task-delete-button {
+  min-width: 72px;
 }
 
 .empty-state {

--- a/src/features/tasks/components/TaskCard.tsx
+++ b/src/features/tasks/components/TaskCard.tsx
@@ -6,10 +6,11 @@ import {
 import type { Task } from '../types'
 
 type TaskCardProps = {
+  onDeleteTask: (taskId: string) => void
   task: Task
 }
 
-export function TaskCard({ task }: TaskCardProps) {
+export function TaskCard({ onDeleteTask, task }: TaskCardProps) {
   return (
     <article className="task-card">
       <div className="task-card-main">
@@ -31,6 +32,16 @@ export function TaskCard({ task }: TaskCardProps) {
           <dd>{task.dueDate ?? '未設定'}</dd>
         </div>
       </dl>
+
+      <div className="task-card-actions">
+        <button
+          className="secondary-button task-delete-button"
+          type="button"
+          onClick={() => onDeleteTask(task.id)}
+        >
+          削除
+        </button>
+      </div>
     </article>
   )
 }

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -23,6 +23,12 @@ function TasksPage() {
     setTasks((currentTasks) => [...currentTasks, newTask])
   }
 
+  function handleDeleteTask(taskId: string) {
+    setTasks((currentTasks) =>
+      currentTasks.filter((task) => task.id !== taskId),
+    )
+  }
+
   return (
     <section className="page-section">
       <div className="page-heading">
@@ -38,7 +44,11 @@ function TasksPage() {
       {tasks.length > 0 ? (
         <div className="task-list" aria-label="タスク一覧">
           {tasks.map((task) => (
-            <TaskCard key={task.id} task={task} />
+            <TaskCard
+              key={task.id}
+              task={task}
+              onDeleteTask={handleDeleteTask}
+            />
           ))}
         </div>
       ) : (


### PR DESCRIPTION
## 概要

タスク一覧から任意のタスクを削除できるようにしました。DB保存やlocalStorage保存はまだ行わず、Reactのstate上で削除を反映します。

## 変更内容

- TaskCard に削除ボタンを追加
- TasksPage に handleDeleteTask を追加
- TaskCard から削除対象の id を親へ渡すpropsを追加
- setTasks と filter で削除対象以外のタスクだけを残す
- 削除ボタン用の最小限のスタイルを追加

## 動作確認

- [x] npm run lint
- [x] npm run build
- [x] /tasks がローカル開発サーバーで表示されることを確認

Closes #19